### PR TITLE
parse_osc: fix error when using --bbox

### DIFF
--- a/scripts/parse_osc.pl
+++ b/scripts/parse_osc.pl
@@ -157,7 +157,7 @@ sub process_osc {
                 if( $r->name eq 'node' ) {
                     my $lat = $r->getAttribute('lat');
                     my $lon = $r->getAttribute('lon');
-                    next if $lon < $bbox[0] || $lon > $bbox[2] || $lat < $bbox[1] || $lat > $bbox[2];
+                    next if $lon < $bbox[0] || $lon > $bbox[2] || $lat < $bbox[1] || $lat > $bbox[3];
                     $lat = floor($lat / $tile_size);
                     #$lat = int(89/$tile_size) if $lat >= 90/$tile_size;
                     $lon = floor($lon / $tile_size);


### PR DESCRIPTION
Using the wrong bbox element causes node not to be inserted into database